### PR TITLE
chroma-hnswlib 0.7.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - numpy
   run:
     - python
+    - numpy
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,21 +6,21 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 4dce282543039681160259d29fcde6151cc9106c6461e0485f57cdccd83059b7
 
 build:
-  number: 1
+  number: 0
+  skip: true  # [py<310]
   script:
-    # HNSWLIB_NO_NATIVE is set to build without "--march=native"
-    - export HNSWLIB_NO_NATIVE=1 && {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv  # [unix]
-    - set HNSWLIB_NO_NATIVE=1 && {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv  # [win]
+    # HNSWLIB_NO_NATIVE disables -march=native for portable conda builds
+    - export HNSWLIB_NO_NATIVE=1 && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation  # [unix]
+    - set HNSWLIB_NO_NATIVE=1 && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation  # [win]
 
 requirements:
-  # see https://github.com/conda-forge/hnswlib-feedstock/blob/main/recipe/meta.yaml
   build:
     - {{ compiler('cxx') }}
-    - {{ stdlib("c") }}
+    - {{ stdlib('c') }}
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - python                                 # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
@@ -28,6 +28,7 @@ requirements:
     - python
     - pip
     - setuptools >=42
+    - wheel
     - pybind11 >=2.0
     - numpy
   run:
@@ -36,15 +37,16 @@ requirements:
 test:
   imports:
     - hnswlib
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/chroma-core/hnswlib
   summary: Chromas fork of hnswlib
   license: Apache-2.0
+  license_family: APACHE
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,10 +45,16 @@ test:
 
 about:
   home: https://github.com/chroma-core/hnswlib
-  summary: Chromas fork of hnswlib
+  summary: Chroma's fork of hnswlib
+  description: |
+    Chroma's fork of hnswlib - a header-only C++/Python library for fast
+    approximate nearest-neighbor search. Used as the default in-memory
+    vector index by chromadb.
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
+  doc_url: https://github.com/chroma-core/hnswlib
+  dev_url: https://github.com/chroma-core/hnswlib
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
chroma-hnswlib 0.7.6

**Destination channel:** defaults

### Links

- [PKG-14499](https://anaconda.atlassian.net/browse/PKG-14499) (blocks PKG-7382 chromadb)
- [Upstream repository](https://github.com/chroma-core/hnswlib)
- Conda-forge recipe: https://github.com/conda-forge/chroma-hnswlib-feedstock/blob/main/recipe/meta.yaml

### Explanation of changes:

- **First release of `chroma-hnswlib` to pkgs/main.** AnacondaRecipes fork has been at v0.7.6 since recipe sync but never released. Required as runtime dep for chromadb 1.5.8 (PKG-7382), where `chromadb/segment/impl/vector/local_hnsw.py` does `import hnswlib`.
- **Build:** C++ extension via pybind11. `HNSWLIB_NO_NATIVE=1` env disables `-march=native` so the resulting binary is portable across the conda matrix (recipe behavior preserved from conda-forge).

[PKG-14499]: https://anaconda.atlassian.net/browse/PKG-14499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ